### PR TITLE
Implemented file-server-post task

### DIFF
--- a/03-streams/01-limit-size-stream/LimitSizeStream.js
+++ b/03-streams/01-limit-size-stream/LimitSizeStream.js
@@ -4,10 +4,20 @@ const LimitExceededError = require('./LimitExceededError');
 class LimitSizeStream extends stream.Transform {
   constructor(options) {
     super(options);
+    this.limit = options.limit;
+    this.encoding = options.encoding;
+    this.bytesPassed = 0;
   }
 
-  _transform(chunk, encoding, callback) {
+  _transform(chunk, _encoding, callback) {
+    const chunkSize = Buffer.byteLength(chunk);
 
+    if (this.bytesPassed + chunkSize <= this.limit) {
+      callback(null, chunk);
+      this.bytesPassed += chunkSize;
+    } else {
+      callback(new LimitExceededError(), chunk);
+    }
   }
 }
 

--- a/03-streams/03-file-server-get/server.js
+++ b/03-streams/03-file-server-get/server.js
@@ -1,24 +1,50 @@
-const url = require('url');
 const http = require('http');
 const path = require('path');
+const {createReadStream} = require('fs');
 
 const server = new http.Server();
 
 server.on('request', (req, res) => {
-  const url = new URL(req.url, `http://${req.headers.host}`);
-  const pathname = url.pathname.slice(1);
-
-  const filepath = path.join(__dirname, 'files', pathname);
-
-  switch (req.method) {
-    case 'GET':
-
-      break;
-
-    default:
-      res.statusCode = 501;
-      res.end('Not implemented');
+  if (req.method !== 'GET') {
+    res.statusCode = 501;
+    res.end('Not implemented');
+    return;
   }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const pathToFile = path.parse(url.pathname);
+
+  if (pathToFile.dir !== '/') {
+    res.statusCode = 400;
+    res.end('Nested folders are not supported');
+    return;
+  }
+
+  if (pathToFile.ext === '') {
+    res.statusCode = 400;
+    res.end('File extension is missing');
+    return;
+  }
+
+  const filepath = path.join(__dirname, 'files', pathToFile.base);
+
+  const readStream = createReadStream(filepath);
+
+  readStream.on('error', (err) => {
+    if (err.code === 'ENOENT') {
+      res.statusCode = 404;
+      res.end('File does not exist');
+      return;
+    }
+
+    res.statusCode = 500;
+    res.end('Server error');
+    return;
+  }).pipe(res);
+
+  req.on('aborted', () => {
+    readStream.destroy();
+  });
 });
 
 module.exports = server;

--- a/03-streams/04-file-server-post/server.js
+++ b/03-streams/04-file-server-post/server.js
@@ -1,24 +1,73 @@
-const url = require('url');
 const http = require('http');
 const path = require('path');
+const {createWriteStream, rm} = require('fs');
+const {pipeline} = require('stream');
+const LimitSizeStream = require('./LimitSizeStream');
+
+const ONE_MEGABYTE_IN_BYTES = 1048576;
 
 const server = new http.Server();
 
 server.on('request', (req, res) => {
-  const url = new URL(req.url, `http://${req.headers.host}`);
-  const pathname = url.pathname.slice(1);
-
-  const filepath = path.join(__dirname, 'files', pathname);
-
-  switch (req.method) {
-    case 'POST':
-
-      break;
-
-    default:
-      res.statusCode = 501;
-      res.end('Not implemented');
+  if (req.method !== 'POST') {
+    res.statusCode = 501;
+    res.end('Not implemented');
+    return;
   }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const pathToFile = path.parse(url.pathname);
+
+  if (pathToFile.dir !== '/') {
+    res.statusCode = 400;
+    res.end('Nested folders are not supported');
+    return;
+  }
+
+  if (pathToFile.ext === '') {
+    res.statusCode = 400;
+    res.end('File extension is missing');
+    return;
+  }
+
+
+  const filepath = path.join(__dirname, 'files', pathToFile.base);
+  const writeStream = createWriteStream(filepath, {flags: 'wx'});
+  const limitSizeStream = new LimitSizeStream({limit: ONE_MEGABYTE_IN_BYTES});
+
+  pipeline(
+      req,
+      limitSizeStream,
+      writeStream,
+      (err) => {
+        if (err) {
+          switch (err.code) {
+            case 'LIMIT_EXCEEDED':
+              rm(filepath, {force: true}, () => {
+                res.statusCode = 413;
+                res.end('Limit exceeded');
+              });
+              return;
+            case 'EEXIST':
+              res.statusCode = 409;
+              res.end('File already exists');
+              return;
+            case 'ECONNRESET':
+              rm(filepath, {force: true}, () => {
+                res.end();
+              });
+              return;
+            default:
+              res.statusCode = 500;
+              res.end('Server error');
+              return;
+          }
+        }
+
+        res.statusCode = 201;
+        res.end();
+      },
+  );
 });
 
 module.exports = server;


### PR DESCRIPTION
⚠️To be reviewed after #3 and #4 ⚠️

Everything works as expected:

```bash
curl --data-binary 
@C:\Users\admin\Desktop\nodejs-course\2-streams.mp4 --limit-rate 100k -i -X 
"POST " http://localhost:3000/2-streams.mp4
HTTP/1.1 100 Continue

HTTP/1.1 413 Payload Too Large
Date: Sun, 13 Mar 2022 18:35:45 GMT
Connection: keep-alive
Keep-Alive: timeout=5
Content-Length: 14

Limit exceeded
```

However when I run tests one of them fail:
```
1) streams/file-server-post
       тесты на файловый сервер
         POST
           при попытке создания слишком большого файла - ошибка 413:        
     Error: write ECONNABORTED
      at afterWriteDispatched (node:internal/stream_base_commons:160:15)    
      at writevGeneric (node:internal/stream_base_commons:143:3)
      at Socket._writeGeneric (node:net:793:11)
      at Socket._writev (node:net:802:8)
      at doWrite (node:internal/streams/writable:407:12)
      at clearBuffer (node:internal/streams/writable:562:5)
      at Socket.Writable.uncork (node:internal/streams/writable:349:7)      
      at connectionCorkNT (node:_http_outgoing:797:8)
      at processTicksAndRejections (node:internal/process/task_queues:82:21)
``` 

I believe the test should be fixed. It is probably because I use `stream.pipeline` and req.destroy is called which causes ECONNABORTED error in test. @tadjik1 What do you think?